### PR TITLE
fix: UNI-265 update get courses route archived courses

### DIFF
--- a/migration/src/migrate/repository.ts
+++ b/migration/src/migrate/repository.ts
@@ -17,12 +17,7 @@ export default class MigrationRepository {
   }
 
   async insertCourses(courses: CourseEntity[]): Promise<void> {
-    await this.manager
-      .createQueryBuilder()
-      .insert()
-      .into("courses")
-      .values(courses)
-      .execute();
+    await this.manager.save(courses, { chunk: 1000 });
   }
 
   async updateUser(zid: string) {

--- a/migration/src/migrate/service.ts
+++ b/migration/src/migrate/service.ts
@@ -135,7 +135,7 @@ export default class MigrationService {
           console.log("Unknown term: ", term);
         }
       }
-      return termNums;
+      return termNums.filter((term) => !isNaN(term));
     };
 
     const entity = new CourseEntity();


### PR DESCRIPTION
## Description
Martin from Circles updated the `courses/dump` route in the Circles API to now include archived courses into the response payload. While the endpoint now works fine, I've had to modify how course migration data is inserted into Postgres. As Postgres limits the amount of placeholders you can have in a query, and we have now included more data to insert, running as is produces this error:
```
curl -X POST localhost:8080/api/v1/migrate/courses
{"status":"FAILURE","message":"bind message has 8640 parameter formats but 0 parameters"}
```
This [Type ORM Issue](https://github.com/typeorm/typeorm/issues/3044) I found highlights this limitation.

I've updated the `insertCourses` function query to now chunk the course data that gets inserted instead of using the `createQueryBuilder`. I've also had to filter out junk data being parsed when parsing the term array in `convertCourseToEntity` since some of the terms being parsed came up as `NaN` inside of the term array, preventing Postgres from inserting the tables. Although I'm not too sure if archived courses should even have term numbers parsed and should just have an empty array instead as a placeholder, would like some input on this.

## After
Now, running the commands produces this:
```
curl -X POST localhost:8080/api/v1/migrate/courses
{"status":"SUCCESS","message":"Successfully migrated courses"}  
curl -X POST localhost:8080/api/v1/migrate/reviews
{"status":"SUCCESS","message":"Successfully migrated reviews"}
```
and course reviews are now present in the local dev environment:
![image](https://github.com/devsoc-unsw/unilectives/assets/87012111/07b62374-d75d-4cfd-b536-14d32649687e)
