### PR TITLE
fix/UNI-266 : Updated SQL query to remove duplicate course cards

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Uni-lectives
 
-Copyright (C) 2023 CSESoc UNSW 
+Copyright (C) 2023 DevSoc UNSW
 
 This program is free software: you can redistribute it and/or modify it under 
 the terms of the GNU Affero General Public License as published by the Free 
@@ -37,7 +37,7 @@ party components included in the software.
 6. If you use this software in a product that is freely available to the
 public, you must give full credit to the original authors of the software by
 prominently displaying the following attribution in the product: "This product
-includes software developed by CSESoc UNSW."
+includes software developed by DevSoc UNSW."
 
 7. This license extension shall not be interpreted to affect the validity or 
 enforceability of the AGPL-v3 license. 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
-# cselectives-v2
+# unilectives
 
 A website to review UNSW courses and electives.
 
 ## Branch conventions
 
 Type: feature, task, bugfix, refactor
-Jira Ticket: ELEC-XXX
+[type]/UNI-XXX-[opt. description-in-kebab-case]
 
-{type}/{jira-ticket}
-
-e.g. feature/ELEC-777
+e.g. feature/UNI-777-the-brown-fox
 
 ## Running Locally
 

--- a/backend/src/repositories/course.repository.ts
+++ b/backend/src/repositories/course.repository.ts
@@ -72,7 +72,7 @@ export class CourseRepository {
     FROM courses c
     LEFT JOIN reviews r ON c.course_code = r.course_code
     GROUP BY c.course_code
-    ORDER BY "reviewCount" DESC
+    ORDER BY "reviewCount" DESC, c.course_code ASC
     LIMIT 25 OFFSET ${offset};
     `) as any[];
     return courses;

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -9,7 +9,7 @@ import { Course, Courses } from "@/types/api";
 export async function generateMetadata(): Promise<Metadata> {
   return {
     title: `Home | Unilectives - UNSW Course Reviews`,
-    description: `A course review website for UNSW made by CSESoc`,
+    description: `A course review website for UNSW made by DevSoc`,
   };
 }
 
@@ -66,7 +66,7 @@ export default async function Home() {
         <div className="flex flex-row w-5/6 space-y-0 justify-between items-left md:space-y-4 md:flex-col md:items-center">
           <div className="flex flex-col w-full gap-3">
             <p className="drop-shadow-md text-base sm:text-xs">
-              CSESoc presents
+              DevSoc presents
             </p>
             <h1 className="justify-center font-bold text-unilectives-blue text-7xl sm:text-4xl">
               unilectives

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -9,13 +9,13 @@ import { Course, Courses } from "@/types/api";
 export async function generateMetadata(): Promise<Metadata> {
   return {
     title: `Home | Unilectives - UNSW Course Reviews`,
-    description: `A course review website for UNSW made by DevSoc`,
+    description: `UNSW course reviews, ratings, and study tips. Unilectives is your one-stop shop for making informed course choices at UNSW.`,
   };
 }
 
 export default async function Home() {
   const { courses: initialCourses } = (await get(
-    "/courses?offset=0"
+    "/courses?offset=0",
   )) as Courses;
 
   const metaLD: WithContext<ItemList> = {

--- a/frontend/src/app/terms-and-conditions/page.tsx
+++ b/frontend/src/app/terms-and-conditions/page.tsx
@@ -11,8 +11,8 @@ export default function TermsAndConditions() {
       <h1 className="text-lg font-bold">Terms and Conditions</h1>
       <br />
       <p>
-        CSESoc is the constituent student society of UNSW&apos;s School of Computer
-        Science and Engineering. We do not represent the School, Faculty or
+        Software Development Society (DevSoc) is a student society comprised of interested
+        developers, inventors and tech enthusiasts. We do not represent the School, Faculty or
         University.
       </p>
       <br />

--- a/frontend/src/components/Navbar/Navbar.tsx
+++ b/frontend/src/components/Navbar/Navbar.tsx
@@ -279,7 +279,7 @@ export default function Navbar({ userZid }: NavbarProps) {
               .
             </span>
             <span className={collapsed ? "hidden" : "text-xs"}>
-              © CSESoc {new Date().getFullYear()}, v1.0.0
+              © DevSoc {new Date().getFullYear()}, v1.0.0
             </span>
           </div>
         </div>


### PR DESCRIPTION
## Fix:

Issue was that SQL's offset and limit would get really buggy if the order was not strictly set and the old code only ordered by the number of reviews and if the reviews are the same, then the limit + offset would duplicate the courses with the same number of reviews to the new data. Because of this the cache stored this data and would need to be flushed. More info on this problem could be seen [here](https://stackoverflow.com/questions/39680598/querying-with-limit-and-offset-is-there-a-chance-to-have-different-results-with)


