### PR TITLE
fix: UNI-278 Empty search bar not resetting

### DIFF
--- a/frontend/src/components/CoursesList/CoursesList.tsx
+++ b/frontend/src/components/CoursesList/CoursesList.tsx
@@ -32,7 +32,7 @@ export default function CoursesList({
         // default courses
         try {
           const { courses } = (await get(
-            `/courses?offset=${index}`
+            `/courses?offset=${index}`,
           )) as Courses;
           fetchedCourses = courses;
         } catch (err) {
@@ -71,7 +71,7 @@ export default function CoursesList({
     const getSearchResults = async () => {
       try {
         const { courses } = (await get(
-          `/course/search/${searchTerm}`
+          `/course/search/${searchTerm}`,
         )) as Courses;
         searchCoursesRef.current = courses;
       } catch (err) {
@@ -84,6 +84,9 @@ export default function CoursesList({
     const getInitialDisplayCourses = () => {
       if (searchTerm !== "") {
         getSearchResults();
+      } else {
+        setDisplayCourses(initialCourses.slice(0, paginationOffset));
+        setInitialLoading(false);
       }
     };
     const loadOnScroll = () => {
@@ -119,7 +122,7 @@ export default function CoursesList({
                 terms={c.terms}
               />
             </a>
-          )
+          ),
         )}
         {!initialLoading ? (
           <p className="text-center opacity-50">No more courses</p>


### PR DESCRIPTION
The `getInitialDisplayCourses` function does not cover the case where the search string may be changed back to empty, causing the bug where the the `CoursesList` component does not get reset back to the default courses being loaded. Adding an else branch to change the state back to the initial courses state fixes this issue.

https://github.com/devsoc-unsw/unilectives/assets/87012111/44487b57-4fa2-4334-af56-95e5c5b5cc32

