### PR TITLE
chore: UNI-292 linting GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,16 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run build
+  migration-ci:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./migration
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run build

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint -c .eslintrc.js \"src/**/*.{js,ts,tsx}\" --quiet --fix",
+    "format": "prettier '**/*.ts' --write",
     "build": "tsc",
     "start": "npx prisma migrate deploy && node dist/src/index.js",
     "dev": "NODE_ENV=dev tsx src/index.ts",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "format": "prettier '**/*.ts{,x}' --write"
   },
   "dependencies": {
     "@headlessui/react": "^1.7.14",

--- a/migration/package.json
+++ b/migration/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "tsc",
     "lint": "eslint -c eslint.config.js \"src/**/*.{js,ts,tsx}\" --quiet --fix",
+    "format": "prettier '**/*.ts' --write",
     "start": "node dist/src/index.js",
     "dev": "NODE_ENV=dev tsx watch src/index.ts",
     "dev:one": "NODE_ENV=dev tsx src/index.ts"

--- a/migration/src/migrate/index.ts
+++ b/migration/src/migrate/index.ts
@@ -26,7 +26,7 @@ export default class MigrationController {
             const result = await this.migrationService.migrateReviews();
             this.logger.info(`Responding to client in POST /migrate/reviews`);
             return res.status(200).json(result);
-          } catch (err: any) {
+          } catch (err) {
             this.logger.warn(
               `An error occurred when trying to POST /migrate/reviews ${err}`,
             );
@@ -48,7 +48,7 @@ export default class MigrationController {
             const result = await this.migrationService.updateReviews();
             this.logger.info(`Responding to client in PUT /migrate/reviews`);
             return res.status(200).json(result);
-          } catch (err: any) {
+          } catch (err) {
             this.logger.warn(
               `An error occurred when trying to PUT /migrate/reviews ${err}`,
             );
@@ -70,7 +70,7 @@ export default class MigrationController {
             const result = await this.migrationService.migrateCourses();
             this.logger.info(`Responding to client in POST /migrate/courses`);
             return res.status(200).json(result);
-          } catch (err: any) {
+          } catch (err) {
             this.logger.warn(
               `An error occurred when trying to POST /migrate/courses ${err}`,
             );
@@ -92,7 +92,7 @@ export default class MigrationController {
             const result = await this.migrationService.updateCourses();
             this.logger.info(`Responding to client in PUT /migrate/courses`);
             return res.status(200).json(result);
-          } catch (err: any) {
+          } catch (err) {
             this.logger.warn(
               `An error occurred when trying to PUT /migrate/courses ${err}`,
             );
@@ -119,7 +119,7 @@ export default class MigrationController {
             const result = await this.migrationService.updateUser(zid);
             this.logger.info(`Responding to client in PUT /users/${zid}`);
             return res.status(200).json(result);
-          } catch (err: any) {
+          } catch (err) {
             this.logger.warn(
               `An error occurred when trying to PUT /users/${zid}: ${err}`,
             );
@@ -141,7 +141,7 @@ export default class MigrationController {
             const result = await this.migrationService.flush();
             this.logger.info(`Responding to client in DELETE /migrate/flush`);
             return res.status(200).json(result);
-          } catch (err: any) {
+          } catch (err) {
             this.logger.warn(
               `An error occurred when trying to DELETE /migrate/flush ${err}`,
             );

--- a/migration/src/migrate/repository.ts
+++ b/migration/src/migrate/repository.ts
@@ -24,25 +24,23 @@ export default class MigrationRepository {
   }
 
   async getReviews(): Promise<IReview[]> {
-    const reviews: any = await this.manager.query(`
-    select * from unilectives.reviews
-    `);
-    return reviews.map((r: any) => ({
-      reviewId: r.review_id,
+    const reviews = await this.manager.getRepository(ReviewEntity).find();
+    return reviews.map((r: ReviewEntity) => ({
+      reviewId: r.reviewId,
       zid: r.zid,
-      courseCode: r.course_code,
-      authorName: r.author_name,
+      courseCode: r.courseCode,
+      authorName: r.authorName,
       title: r.title,
       description: r.description,
-      grade: r.grade,
-      termTaken: r.term_taken,
-      createdTimestamp: r.created_timestamp,
-      updatedTimestamp: r.updated_timestamp,
+      grade: r.grade ? r.grade.toString() : null,
+      termTaken: r.termTaken,
+      createdTimestamp: r.createdTimestamp.toString(),
+      updatedTimestamp: r.updatedTimestamp.toString(),
       upvotes: r.upvotes,
       manageability: r.manageability,
       usefulness: r.usefulness,
       enjoyability: r.enjoyability,
-      overallRating: r.overall_rating,
+      overallRating: r.overallRating,
     }));
   }
 

--- a/migration/src/migrate/service.ts
+++ b/migration/src/migrate/service.ts
@@ -7,11 +7,16 @@ import Fetcher from "./fetcher";
 import MigrationRepository from "./repository";
 
 export default class MigrationService {
+  private readonly logger = console;
   constructor(
     readonly fb: Firebase,
     readonly fetcher: Fetcher,
     readonly migrationRepository: MigrationRepository,
   ) {}
+
+  inferError(err: unknown) {
+    return err instanceof Error ? err.message : "An unknown error occured";
+  }
 
   async migrateReviews(): Promise<IResponse> {
     try {
@@ -40,10 +45,10 @@ export default class MigrationService {
         status: "SUCCESS",
         message: "Successfully migrated reviews",
       };
-    } catch (err: any) {
+    } catch (err) {
       return {
         status: "FAILURE",
-        message: err.message,
+        message: this.inferError(err),
       };
     }
   }
@@ -75,10 +80,10 @@ export default class MigrationService {
         status: "SUCCESS",
         message: "Successfully migrated reviews",
       };
-    } catch (err: any) {
+    } catch (err) {
       return {
         status: "FAILURE",
-        message: err.message,
+        message: this.inferError(err),
       };
     }
   }
@@ -121,10 +126,10 @@ export default class MigrationService {
         status: "SUCCESS",
         message: "Successfully updated reviews",
       };
-    } catch (err: any) {
+    } catch (err) {
       return {
         status: "FAILURE",
-        message: err.message,
+        message: this.inferError(err),
       };
     }
   }
@@ -138,10 +143,10 @@ export default class MigrationService {
         status: "SUCCESS",
         message: "Successfully migrated courses",
       };
-    } catch (err: any) {
+    } catch (err) {
       return {
         status: "FAILURE",
-        message: err.message,
+        message: this.inferError(err),
       };
     }
   }
@@ -155,10 +160,10 @@ export default class MigrationService {
         status: "SUCCESS",
         message: "Successfully updated courses",
       };
-    } catch (err: any) {
+    } catch (err) {
       return {
         status: "FAILURE",
-        message: err.message,
+        message: this.inferError(err),
       };
     }
   }
@@ -170,10 +175,10 @@ export default class MigrationService {
         status: "SUCCESS",
         message: "Successfully updated user to admin" + ` ${zid}`,
       };
-    } catch (err: any) {
+    } catch (err) {
       return {
         status: "FAILURE",
-        message: err.message,
+        message: this.inferError(err),
       };
     }
   }
@@ -185,10 +190,10 @@ export default class MigrationService {
         status: "SUCCESS",
         message: "Successfully flushed database",
       };
-    } catch (err: any) {
+    } catch (err) {
       return {
         status: "FAILURE",
-        message: err.message,
+        message: this.inferError(err),
       };
     }
   }

--- a/migration/src/migrate/service.ts
+++ b/migration/src/migrate/service.ts
@@ -7,7 +7,6 @@ import Fetcher from "./fetcher";
 import MigrationRepository from "./repository";
 
 export default class MigrationService {
-  private readonly logger = console;
   constructor(
     readonly fb: Firebase,
     readonly fetcher: Fetcher,


### PR DESCRIPTION
Add linting action for the migration service, the rest of the services already have the lint action set up for github actions pipeline. Haven't figured out a nice way to get prettier integrated as it may potentially cause issues if ran in CI, instead I just added another script, where running `npm run format` allows each service to be formatted with prettier. Note that adding the migration service means that the type issues with `any` present in the migration service will probably cause the pipeline to fail.