### PR TITLE
chore(actions): replace deployment PAT with app dispatch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GH_TOKEN }}
+          password: ${{ github.token }}
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
@@ -39,9 +39,8 @@ jobs:
           platforms: linux/amd64
           file: ${{ matrix.component }}/Dockerfile
           tags: |
-            ghcr.io/csesoc/unilectives-${{ matrix.component }}:${{ github.sha }}
-            ghcr.io/csesoc/unilectives-${{ matrix.component }}:latest
-          labels: ${{ steps.meta.outputs.labels }}
+            ghcr.io/devsoc-unsw/unilectives-${{ matrix.component }}:${{ github.sha }}
+            ghcr.io/devsoc-unsw/unilectives-${{ matrix.component }}:latest
   deploy-staging:
     name: Deploy Staging (CD)
     runs-on: ubuntu-latest
@@ -52,29 +51,18 @@ jobs:
       url: https://cselectives.staging.csesoc.unsw.edu.au
     if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/develop' }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - name: Dispatch deployment
+        uses: devsoc-unsw/deployment-dispatch-action@main
         with:
-          repository: csesoc/deployment
-          token: ${{ secrets.GH_TOKEN }}
+          deployment-dispatcher-app-id: ${{ vars.CSESOC_DEPLOYMENT_DISPATCHER_APP_ID }}
+          deployment-dispatcher-app-private-key: ${{ secrets.CSESOC_DEPLOYMENT_DISPATCHER_APP_PRIVATE_KEY }}
+          owner: csesoc
+          repository: deployment
           ref: develop
-      - name: Install yq - portable yaml processor
-        uses: mikefarah/yq@v4.34.1
-      - name: Update deployment
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: |
-          git config user.name "CSESoc CD"
-          git config user.email "technical@csesoc.org.au"
-          git checkout -b update/unilectives-staging/${{ github.sha }}
-          yq -i '.items[0].spec.template.spec.containers[0].image = "ghcr.io/csesoc/unilectives-backend:${{ github.sha }}"' apps/projects/unilectives/staging/deploy-backend.yml
-          yq -i '.items[0].spec.template.spec.containers[0].image = "ghcr.io/csesoc/unilectives-frontend:${{ github.sha }}"' apps/projects/unilectives/staging/deploy-frontend.yml
-          yq -i '.items[0].spec.template.spec.containers[0].image = "ghcr.io/csesoc/unilectives-migration:${{ github.sha }}"' apps/projects/unilectives/staging/deploy-migration.yml
-          git add .
-          git commit -m "feat(cselectives/staging): update image"
-          git push -u origin update/unilectives-staging/${{ github.sha }}
-          gh pr create -B develop --title "feat(cselectives/staging): update image" --body "Updates the image for the cselectives v2 (staging) deployment to commit csesoc/cselectives-v2@${{ github.sha }}." > URL
-          gh pr merge $(cat URL) --squash -d
+          updates: |
+            ghcr.io/devsoc-unsw/unilectives-backend=${{ github.sha }}
+            ghcr.io/devsoc-unsw/unilectives-frontend=${{ github.sha }}
+            ghcr.io/devsoc-unsw/unilectives-migration=${{ github.sha }}
   deploy-prod:
     name: Deploy Production (CD)
     runs-on: ubuntu-latest
@@ -85,26 +73,15 @@ jobs:
       url: https://unilectives.csesoc.app
     if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - name: Dispatch deployment
+        uses: devsoc-unsw/deployment-dispatch-action@main
         with:
-          repository: csesoc/deployment
-          token: ${{ secrets.GH_TOKEN }}
+          deployment-dispatcher-app-id: ${{ vars.CSESOC_DEPLOYMENT_DISPATCHER_APP_ID }}
+          deployment-dispatcher-app-private-key: ${{ secrets.CSESOC_DEPLOYMENT_DISPATCHER_APP_PRIVATE_KEY }}
+          owner: csesoc
+          repository: deployment
           ref: develop
-      - name: Install yq - portable yaml processor
-        uses: mikefarah/yq@v4.27.2
-      - name: Update deployment
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: |
-          git config user.name "CSESoc CD"
-          git config user.email "technical@csesoc.org.au"
-          git checkout -b update/unilectives-prod/${{ github.sha }}
-          yq -i '.items[0].spec.template.spec.containers[0].image = "ghcr.io/csesoc/unilectives-backend:${{ github.sha }}"' apps/projects/unilectives/prod/deploy-backend.yml
-          yq -i '.items[0].spec.template.spec.containers[0].image = "ghcr.io/csesoc/unilectives-frontend:${{ github.sha }}"' apps/projects/unilectives/prod/deploy-frontend.yml
-          yq -i '.items[0].spec.template.spec.containers[0].image = "ghcr.io/csesoc/unilectives-migration:${{ github.sha }}"' apps/projects/unilectives/prod/deploy-migration.yml
-          git add .
-          git commit -m "feat(unilectives/prod): update image"
-          git push -u origin update/unilectives-prod/${{ github.sha }}
-          gh pr create -B develop --title "feat(unilectives/prod): update image" --body "Updates the image for the unilectives v2 (prod) deployment to commit csesoc/cselectives-v2@${{ github.sha }}." > URL
-          gh pr merge $(cat URL) --squash -d
+          updates: |
+            ghcr.io/devsoc-unsw/unilectives-backend=${{ github.sha }}
+            ghcr.io/devsoc-unsw/unilectives-frontend=${{ github.sha }}
+            ghcr.io/devsoc-unsw/unilectives-migration=${{ github.sha }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,8 +39,8 @@ jobs:
           platforms: linux/amd64
           file: ${{ matrix.component }}/Dockerfile
           tags: |
-            ghcr.io/devsoc-unsw/unilectives-${{ matrix.component }}:${{ github.sha }}
-            ghcr.io/devsoc-unsw/unilectives-${{ matrix.component }}:latest
+            ghcr.io/devsoc-unsw/${{ github.ref == 'refs/heads/develop' && format('unilectives-staging-{0}', matrix.component) || format('unilectives-{0}', matrix.component) }}:${{ github.sha }}
+            ghcr.io/devsoc-unsw/${{ github.ref == 'refs/heads/develop' && format('unilectives-staging-{0}', matrix.component) || format('unilectives-{0}', matrix.component) }}:latest
   deploy-staging:
     name: Deploy Staging (CD)
     runs-on: ubuntu-latest
@@ -60,9 +60,9 @@ jobs:
           repository: deployment
           ref: develop
           updates: |
-            ghcr.io/devsoc-unsw/unilectives-backend=${{ github.sha }}
-            ghcr.io/devsoc-unsw/unilectives-frontend=${{ github.sha }}
-            ghcr.io/devsoc-unsw/unilectives-migration=${{ github.sha }}
+            ghcr.io/devsoc-unsw/unilectives-staging-backend=${{ github.sha }}
+            ghcr.io/devsoc-unsw/unilectives-staging-frontend=${{ github.sha }}
+            ghcr.io/devsoc-unsw/unilectives-staging-migration=${{ github.sha }}
   deploy-prod:
     name: Deploy Production (CD)
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,7 +52,6 @@ jobs:
       IMAGE_PREFIX: ${{ github.ref == 'refs/heads/develop' && 'unilectives-staging' || 'unilectives' }}
     environment:
       name: ${{ github.ref == 'refs/heads/develop' && 'staging' || 'prod' }}
-      url: ${{ github.ref == 'refs/heads/develop' && 'https://cselectives.staging.csesoc.unsw.edu.au' || 'https://unilectives.csesoc.app' }}
     if: ${{ github.event_name != 'pull_request' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main') }}
     steps:
       - name: Dispatch deployment

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,8 @@ jobs:
   build:
     name: "Build (${{ matrix.component }})"
     runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: ${{ github.ref == 'refs/heads/develop' && format('unilectives-staging-{0}', matrix.component) || format('unilectives-{0}', matrix.component) }}
     permissions:
       contents: read
       packages: write
@@ -39,17 +41,19 @@ jobs:
           platforms: linux/amd64
           file: ${{ matrix.component }}/Dockerfile
           tags: |
-            ghcr.io/devsoc-unsw/${{ github.ref == 'refs/heads/develop' && format('unilectives-staging-{0}', matrix.component) || format('unilectives-{0}', matrix.component) }}:${{ github.sha }}
-            ghcr.io/devsoc-unsw/${{ github.ref == 'refs/heads/develop' && format('unilectives-staging-{0}', matrix.component) || format('unilectives-{0}', matrix.component) }}:latest
-  deploy-staging:
-    name: Deploy Staging (CD)
+            ghcr.io/devsoc-unsw/${{ env.IMAGE_NAME }}:${{ github.sha }}
+            ghcr.io/devsoc-unsw/${{ env.IMAGE_NAME }}:latest
+  deploy:
+    name: "Deploy (${{ github.ref == 'refs/heads/develop' && 'staging' || 'prod' }})"
     runs-on: ubuntu-latest
     needs: [build]
-    concurrency: staging
+    concurrency: ${{ github.ref == 'refs/heads/develop' && 'staging' || 'prod' }}
+    env:
+      IMAGE_PREFIX: ${{ github.ref == 'refs/heads/develop' && 'unilectives-staging' || 'unilectives' }}
     environment:
-      name: staging
-      url: https://cselectives.staging.csesoc.unsw.edu.au
-    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/develop' }}
+      name: ${{ github.ref == 'refs/heads/develop' && 'staging' || 'prod' }}
+      url: ${{ github.ref == 'refs/heads/develop' && 'https://cselectives.staging.csesoc.unsw.edu.au' || 'https://unilectives.csesoc.app' }}
+    if: ${{ github.event_name != 'pull_request' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main') }}
     steps:
       - name: Dispatch deployment
         uses: devsoc-unsw/deployment-dispatch-action@main
@@ -60,28 +64,6 @@ jobs:
           repository: deployment
           ref: develop
           updates: |
-            ghcr.io/devsoc-unsw/unilectives-staging-backend=${{ github.sha }}
-            ghcr.io/devsoc-unsw/unilectives-staging-frontend=${{ github.sha }}
-            ghcr.io/devsoc-unsw/unilectives-staging-migration=${{ github.sha }}
-  deploy-prod:
-    name: Deploy Production (CD)
-    runs-on: ubuntu-latest
-    needs: [build]
-    concurrency: prod
-    environment:
-      name: prod
-      url: https://unilectives.csesoc.app
-    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
-    steps:
-      - name: Dispatch deployment
-        uses: devsoc-unsw/deployment-dispatch-action@main
-        with:
-          deployment-dispatcher-app-id: ${{ vars.CSESOC_DEPLOYMENT_DISPATCHER_APP_ID }}
-          deployment-dispatcher-app-private-key: ${{ secrets.CSESOC_DEPLOYMENT_DISPATCHER_APP_PRIVATE_KEY }}
-          owner: csesoc
-          repository: deployment
-          ref: develop
-          updates: |
-            ghcr.io/devsoc-unsw/unilectives-backend=${{ github.sha }}
-            ghcr.io/devsoc-unsw/unilectives-frontend=${{ github.sha }}
-            ghcr.io/devsoc-unsw/unilectives-migration=${{ github.sha }}
+            ghcr.io/devsoc-unsw/${{ env.IMAGE_PREFIX }}-backend=${{ github.sha }}
+            ghcr.io/devsoc-unsw/${{ env.IMAGE_PREFIX }}-frontend=${{ github.sha }}
+            ghcr.io/devsoc-unsw/${{ env.IMAGE_PREFIX }}-migration=${{ github.sha }}


### PR DESCRIPTION
## Summary
Replace the legacy PAT-based deployment workflow in `.github/workflows/docker.yml` with the shared `devsoc-unsw/deployment-dispatch-action` flow used in `devsoc-unsw/chaos#721`.

## Changes
- switch GHCR authentication from `secrets.GH_TOKEN` to `github.token`
- publish images to `ghcr.io/devsoc-unsw/...` so the Actions token can create and push the packages
- replace direct checkout/edit/push logic for `csesoc/deployment` with `devsoc-unsw/deployment-dispatch-action@main`
- use `vars.CSESOC_DEPLOYMENT_DISPATCHER_APP_ID` and `secrets.CSESOC_DEPLOYMENT_DISPATCHER_APP_PRIVATE_KEY`
- override the composite action target with `owner: csesoc`, `repository: deployment`, and `ref: develop`
- remove the dangling `steps.meta.outputs.labels` reference so the workflow passes validation

## Verification
- `yq eval '.' .github/workflows/docker.yml > /dev/null`
- `actionlint -color .github/workflows/docker.yml`
- `rg -n "\bGH_TOKEN\b|\bIMAGE_UPDATER_APP_ID\b|\bIMAGE_UPDATER_APP_PRIVATE_KEY\b|ghcr\.io/csesoc" . -S -g '!node_modules'` returns no matches
