### PR TITLE
chore(actions): backport deployment dispatch to develop

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,8 @@ jobs:
   build:
     name: "Build (${{ matrix.component }})"
     runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: ${{ github.ref == 'refs/heads/develop' && format('unilectives-staging-{0}', matrix.component) || format('unilectives-{0}', matrix.component) }}
     permissions:
       contents: read
       packages: write
@@ -30,7 +32,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GH_TOKEN }}
+          password: ${{ github.token }}
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
@@ -39,72 +41,28 @@ jobs:
           platforms: linux/amd64
           file: ${{ matrix.component }}/Dockerfile
           tags: |
-            ghcr.io/csesoc/unilectives-${{ matrix.component }}:${{ github.sha }}
-            ghcr.io/csesoc/unilectives-${{ matrix.component }}:latest
-          labels: ${{ steps.meta.outputs.labels }}
-  deploy-staging:
-    name: Deploy Staging (CD)
+            ghcr.io/devsoc-unsw/${{ env.IMAGE_NAME }}:${{ github.sha }}
+            ghcr.io/devsoc-unsw/${{ env.IMAGE_NAME }}:latest
+  deploy:
+    name: "Deploy (${{ github.ref == 'refs/heads/develop' && 'staging' || 'prod' }})"
     runs-on: ubuntu-latest
     needs: [build]
-    concurrency: staging
+    concurrency: ${{ github.ref == 'refs/heads/develop' && 'staging' || 'prod' }}
+    env:
+      IMAGE_PREFIX: ${{ github.ref == 'refs/heads/develop' && 'unilectives-staging' || 'unilectives' }}
     environment:
-      name: staging
-      url: https://cselectives.staging.csesoc.unsw.edu.au
-    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/develop' }}
+      name: ${{ github.ref == 'refs/heads/develop' && 'staging' || 'prod' }}
+    if: ${{ github.event_name != 'pull_request' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main') }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - name: Dispatch deployment
+        uses: devsoc-unsw/deployment-dispatch-action@main
         with:
-          repository: csesoc/deployment
-          token: ${{ secrets.GH_TOKEN }}
+          deployment-dispatcher-app-id: ${{ vars.CSESOC_DEPLOYMENT_DISPATCHER_APP_ID }}
+          deployment-dispatcher-app-private-key: ${{ secrets.CSESOC_DEPLOYMENT_DISPATCHER_APP_PRIVATE_KEY }}
+          owner: csesoc
+          repository: deployment
           ref: develop
-      - name: Install yq - portable yaml processor
-        uses: mikefarah/yq@v4.34.1
-      - name: Update deployment
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: |
-          git config user.name "CSESoc CD"
-          git config user.email "technical@csesoc.org.au"
-          git checkout -b update/unilectives-staging/${{ github.sha }}
-          yq -i '.items[0].spec.template.spec.containers[0].image = "ghcr.io/csesoc/unilectives-backend:${{ github.sha }}"' apps/projects/unilectives/staging/deploy-backend.yml
-          yq -i '.items[0].spec.template.spec.containers[0].image = "ghcr.io/csesoc/unilectives-frontend:${{ github.sha }}"' apps/projects/unilectives/staging/deploy-frontend.yml
-          yq -i '.items[0].spec.template.spec.containers[0].image = "ghcr.io/csesoc/unilectives-migration:${{ github.sha }}"' apps/projects/unilectives/staging/deploy-migration.yml
-          git add .
-          git commit -m "feat(cselectives/staging): update image"
-          git push -u origin update/unilectives-staging/${{ github.sha }}
-          gh pr create -B develop --title "feat(cselectives/staging): update image" --body "Updates the image for the cselectives v2 (staging) deployment to commit csesoc/cselectives-v2@${{ github.sha }}." > URL
-          gh pr merge $(cat URL) --squash -d
-  deploy-prod:
-    name: Deploy Production (CD)
-    runs-on: ubuntu-latest
-    needs: [build]
-    concurrency: prod
-    environment:
-      name: prod
-      url: https://unilectives.csesoc.app
-    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          repository: csesoc/deployment
-          token: ${{ secrets.GH_TOKEN }}
-          ref: develop
-      - name: Install yq - portable yaml processor
-        uses: mikefarah/yq@v4.27.2
-      - name: Update deployment
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: |
-          git config user.name "CSESoc CD"
-          git config user.email "technical@csesoc.org.au"
-          git checkout -b update/unilectives-prod/${{ github.sha }}
-          yq -i '.items[0].spec.template.spec.containers[0].image = "ghcr.io/csesoc/unilectives-backend:${{ github.sha }}"' apps/projects/unilectives/prod/deploy-backend.yml
-          yq -i '.items[0].spec.template.spec.containers[0].image = "ghcr.io/csesoc/unilectives-frontend:${{ github.sha }}"' apps/projects/unilectives/prod/deploy-frontend.yml
-          yq -i '.items[0].spec.template.spec.containers[0].image = "ghcr.io/csesoc/unilectives-migration:${{ github.sha }}"' apps/projects/unilectives/prod/deploy-migration.yml
-          git add .
-          git commit -m "feat(unilectives/prod): update image"
-          git push -u origin update/unilectives-prod/${{ github.sha }}
-          gh pr create -B develop --title "feat(unilectives/prod): update image" --body "Updates the image for the unilectives v2 (prod) deployment to commit csesoc/cselectives-v2@${{ github.sha }}." > URL
-          gh pr merge $(cat URL) --squash -d
+          updates: |
+            ghcr.io/devsoc-unsw/${{ env.IMAGE_PREFIX }}-backend=${{ github.sha }}
+            ghcr.io/devsoc-unsw/${{ env.IMAGE_PREFIX }}-frontend=${{ github.sha }}
+            ghcr.io/devsoc-unsw/${{ env.IMAGE_PREFIX }}-migration=${{ github.sha }}


### PR DESCRIPTION
## Summary
Backport the merged deployment workflow migration from `main` into `develop` without merging the rest of `main`.

## Why Backport Instead Of Merging `main`
`origin/main` and `origin/develop` currently differ in unrelated backend and CI changes, so merging `main` into `develop` just to carry this workflow update would pull in a much larger change set than necessary.

## Changes
- switch GHCR authentication from `secrets.GH_TOKEN` to `github.token`
- publish images to `ghcr.io/devsoc-unsw/...`
- use `devsoc-unsw/deployment-dispatch-action@main` with `vars.CSESOC_DEPLOYMENT_DISPATCHER_APP_ID` and `secrets.CSESOC_DEPLOYMENT_DISPATCHER_APP_PRIVATE_KEY`
- target `csesoc/deployment` via `owner: csesoc`
- keep distinct staging image names on `develop`
- keep the unified deploy job shape from the merged `main` change

## Source
Backports the workflow change merged in #392 on 2026-04-05.

## Verification
- `yq eval '.' .github/workflows/docker.yml > /dev/null`
- `actionlint -color .github/workflows/docker.yml`
